### PR TITLE
feat: add Credits, Measurements, CatalogProducts, ProductConsumptions clients [ENG-4439]

### DIFF
--- a/vayu_sdk/apis/__init__.py
+++ b/vayu_sdk/apis/__init__.py
@@ -20,3 +20,16 @@ from .api_meters import (AggregationMethod, AggregationOperator, Condition,
                          MetersAPI, UpdateMeterRequest, UpdateMeterResponse)
 from .api_webhooks import (NotificationEventType, WebhooksAPI,
                            WebhookSubscribeRequest)
+from .api_credits import (CreditsAPI, DeductCreditsRequest, GrantCreditsRequest,
+                          ListCreditLedgerEntriesResponse)
+from .api_measurements import (CreateMeasurementRequest, CreateMeasurementResponse,
+                               DeleteMeasurementResponse, GetMeasurementResponse,
+                               ListMeasurementsResponse, MeasurementsAPI)
+from .api_catalog_products import (CatalogProductsAPI, CreateCatalogProductRequest,
+                                   CreateCatalogProductResponse, DeleteCatalogProductResponse,
+                                   GetCatalogProductResponse, ListCatalogProductsResponse,
+                                   UpdateCatalogProductRequest, UpdateCatalogProductResponse)
+from .api_product_consumptions import (GetProductConsumptionResponse,
+                                       ProductConsumptionsAPI)
+from .api_customers import (GetCustomerProductsConsumptionsResponse,
+                            GetCustomerProductsConsumptionsByAliasResponse)

--- a/vayu_sdk/apis/api_catalog_products.py
+++ b/vayu_sdk/apis/api_catalog_products.py
@@ -1,0 +1,34 @@
+# vayu_sdk/apis/api_catalog_products.py
+from openapi.api.catalog_products_api import CatalogProductsApi
+from vayu_sdk.clients.vayu_client import VayuClient
+from openapi.models.create_catalog_product_request import CreateCatalogProductRequest
+from openapi.models.create_catalog_product_response import CreateCatalogProductResponse
+from openapi.models.delete_catalog_product_response import DeleteCatalogProductResponse
+from openapi.models.get_catalog_product_response import GetCatalogProductResponse
+from openapi.models.list_catalog_products_response import ListCatalogProductsResponse
+from openapi.models.update_catalog_product_request import UpdateCatalogProductRequest
+from openapi.models.update_catalog_product_response import UpdateCatalogProductResponse
+
+
+class CatalogProductsAPI:
+    __client: CatalogProductsApi = None
+
+    def __init__(self, vayu_client: VayuClient):
+        self.__client = CatalogProductsApi(vayu_client.client)
+
+    def create(self, request: CreateCatalogProductRequest):
+        return self.__client.create_catalog_product(create_catalog_product_request=request)
+
+    def delete(self, id: str):
+        return self.__client.delete_catalog_product(catalog_product_id=id)
+
+    def get(self, id: str):
+        return self.__client.get_catalog_product(catalog_product_id=id)
+
+    def list(self, limit: int = None, cursor: str = None):
+        return self.__client.list_catalog_products(limit=limit, cursor=cursor)
+
+    def update(self, id: str, request: UpdateCatalogProductRequest):
+        return self.__client.update_catalog_product(
+            update_catalog_product_request=request, catalog_product_id=id
+        )

--- a/vayu_sdk/apis/api_credits.py
+++ b/vayu_sdk/apis/api_credits.py
@@ -1,0 +1,24 @@
+# vayu_sdk/apis/api_credits.py
+from openapi.api.credits_api import CreditsApi
+from vayu_sdk.clients.vayu_client import VayuClient
+from openapi.models.deduct_credits_request import DeductCreditsRequest
+from openapi.models.grant_credits_request import GrantCreditsRequest
+from openapi.models.list_credit_ledger_entries_response import ListCreditLedgerEntriesResponse
+
+
+class CreditsAPI:
+    __client: CreditsApi = None
+
+    def __init__(self, vayu_client: VayuClient):
+        self.__client = CreditsApi(vayu_client.client)
+
+    def deduct(self, request: DeductCreditsRequest):
+        return self.__client.deduct_credits(deduct_credits_request=request)
+
+    def grant(self, request: GrantCreditsRequest):
+        return self.__client.grant_credits(grant_credits_request=request)
+
+    def list_ledger_entries(self, customer_id: str, limit: int = None, cursor: str = None):
+        return self.__client.list_credit_ledger_entries(
+            customer_id=customer_id, limit=limit, cursor=cursor
+        )

--- a/vayu_sdk/apis/api_customers.py
+++ b/vayu_sdk/apis/api_customers.py
@@ -15,6 +15,8 @@ from openapi.models.create_customer_response import CreateCustomerResponse
 from openapi.models.update_customer_response import UpdateCustomerResponse
 from openapi.models.delete_customer_response import DeleteCustomerResponse
 from openapi.models.address import Address
+from openapi.models.get_customer_products_consumptions_response import GetCustomerProductsConsumptionsResponse
+from openapi.models.get_customer_products_consumptions_by_alias_response import GetCustomerProductsConsumptionsByAliasResponse
 
 
 Customer = CreateCustomerResponseCustomer
@@ -58,3 +60,9 @@ class CustomersAPI:
         response = self.__client.delete_customer(customer_id=id)
 
         return response
+
+    def get_products_consumptions(self, customer_id: str):
+        return self.__client.get_customer_products_consumptions(customer_id=customer_id)
+
+    def get_products_consumptions_by_alias(self, alias: str):
+        return self.__client.get_customer_products_consumptions_by_alias(alias=alias)

--- a/vayu_sdk/apis/api_measurements.py
+++ b/vayu_sdk/apis/api_measurements.py
@@ -1,0 +1,27 @@
+# vayu_sdk/apis/api_measurements.py
+from openapi.api.measurements_api import MeasurementsApi
+from vayu_sdk.clients.vayu_client import VayuClient
+from openapi.models.create_measurement_request import CreateMeasurementRequest
+from openapi.models.create_measurement_response import CreateMeasurementResponse
+from openapi.models.delete_measurement_response import DeleteMeasurementResponse
+from openapi.models.get_measurement_response import GetMeasurementResponse
+from openapi.models.list_measurements_response import ListMeasurementsResponse
+
+
+class MeasurementsAPI:
+    __client: MeasurementsApi = None
+
+    def __init__(self, vayu_client: VayuClient):
+        self.__client = MeasurementsApi(vayu_client.client)
+
+    def create(self, request: CreateMeasurementRequest):
+        return self.__client.create_measurement(create_measurement_request=request)
+
+    def delete(self, id: str):
+        return self.__client.delete_measurement(measurement_id=id)
+
+    def get(self, id: str):
+        return self.__client.get_measurement(measurement_id=id)
+
+    def list(self, limit: int = None, cursor: str = None):
+        return self.__client.list_measurements(limit=limit, cursor=cursor)

--- a/vayu_sdk/apis/api_product_consumptions.py
+++ b/vayu_sdk/apis/api_product_consumptions.py
@@ -1,0 +1,14 @@
+# vayu_sdk/apis/api_product_consumptions.py
+from openapi.api.product_consumptions_api import ProductConsumptionsApi
+from vayu_sdk.clients.vayu_client import VayuClient
+from openapi.models.get_product_consumption_response import GetProductConsumptionResponse
+
+
+class ProductConsumptionsAPI:
+    __client: ProductConsumptionsApi = None
+
+    def __init__(self, vayu_client: VayuClient):
+        self.__client = ProductConsumptionsApi(vayu_client.client)
+
+    def get(self, product_id: str):
+        return self.__client.get_product_consumption(product_id=product_id)

--- a/vayu_sdk/vayu.py
+++ b/vayu_sdk/vayu.py
@@ -35,7 +35,23 @@ class Vayu:
     @property
     def webhooks(self) -> WebhooksAPI:
         return WebhooksAPI(self.__client)
-    
+
+    @property
+    def credits(self) -> CreditsAPI:
+        return CreditsAPI(self.__client)
+
+    @property
+    def measurements(self) -> MeasurementsAPI:
+        return MeasurementsAPI(self.__client)
+
+    @property
+    def catalog_products(self) -> CatalogProductsAPI:
+        return CatalogProductsAPI(self.__client)
+
+    @property
+    def product_consumptions(self) -> ProductConsumptionsAPI:
+        return ProductConsumptionsAPI(self.__client)
+
     def login(self):
         """Deprecated: Authentication is now handled automatically. You can remove this call."""
         self.__client.login()


### PR DESCRIPTION
## Summary
- Add `CreditsAPI` with `deduct`, `grant`, `list_ledger_entries`
- Add `MeasurementsAPI` with `create`, `delete`, `get`, `list`
- Add `CatalogProductsAPI` with `create`, `delete`, `get`, `list`, `update`
- Add `ProductConsumptionsAPI` with `get`
- Fix `CustomersAPI`: add missing `get_products_consumptions`, `get_products_consumptions_by_alias`

## Test plan
- [ ] `python -c "from vayu_sdk.vayu import Vayu; print('OK')"` passes
- [ ] Manual test: credits, measurements, catalog_products endpoints work

🤖 Generated with [Claude Code](https://claude.com/claude-code)